### PR TITLE
Add development environment setup (AGENTS.md + neon local config)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ JoyJoin is an npm workspaces monorepo with 4 apps and 1 shared package. See `REA
 | `apps/server` | 5000 | Express API + WebSocket server |
 | `apps/user-client` | 5001 | User-facing React PWA (mobile-first) |
 | `apps/admin-client` | 5002 | Admin portal React SPA |
+| `apps/mini-program` | 10086 (H5) | Taro 4 + React WeChat Mini Program |
 | `packages/shared` | — | Shared types, schema, constants |
 
 ### Database (local PostgreSQL + neon wsproxy)
@@ -69,8 +70,27 @@ See `README.md` § "Validation commands" for full list. Key commands:
 - `npm run test` — tests across all workspaces (vitest for server)
 - `npm run lint` — lint all workspaces (currently aliased to typecheck)
 
+### WeChat Mini Program (`apps/mini-program`)
+
+Built with Taro 4.1.11 + React. See `apps/mini-program/README.md` for the full reference.
+
+**Build targets:**
+- `npm run build:weapp -w mini-program` — WeChat weapp (output in `apps/mini-program/dist/`)
+- `npm run build:h5 -w mini-program` — H5 web build
+- `npm run dev:h5 -w mini-program` — H5 dev server on port 10086
+- `npm run dev:weapp -w mini-program` — weapp watch mode (requires WeChat DevTools to preview)
+
+**Typecheck:** `npm run typecheck -w mini-program`
+
+**Tests:** `npx vitest run` from `apps/mini-program/` (no test script in package.json; vitest is hoisted). 13/17 test files pass; 4 failures are pre-existing (`@shared/api` alias not resolved by vitest, and api.test.ts assertion mismatches).
+
+**WeChat DevTools:** The weapp target requires WeChat DevTools (macOS/Windows only) to preview the native mini-program. In headless Cloud Agent VMs, use `build:weapp` to verify the build succeeds and `dev:h5` for live browser preview of the H5 rendition.
+
+**API base URL:** The mini-program resolves its API target from `TARO_APP_API_BASE_URL` > `API_URL` > `APP_URL` > `http://localhost:5001` (default). In local dev, the H5 mode connects to the user-client Vite proxy on 5001, which proxies `/api` to the server on 5000.
+
 ### Known issues in current codebase
 
 - `apps/user-client` has pre-existing TypeScript errors in `MatchingStatusPage.tsx` (null vs undefined type narrowing).
 - One server test (`orchestrationKickoff.test.ts`) expects `.vscode/settings.json` which may not exist.
 - The user client root page (`/`) may show a blank page due to a pre-existing runtime error in `DiscoverPage.tsx`; other routes like `/personality-test` render correctly.
+- Mini-program vitest: 3 payment-related test files fail due to unresolved `@shared/api` alias; `api.test.ts` has 2 assertion mismatches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Architecture overview
+
+JoyJoin is an npm workspaces monorepo with 4 apps and 1 shared package. See `README.md` for full structure and commands.
+
+| Workspace | Port | Purpose |
+|---|---|---|
+| `apps/server` | 5000 | Express API + WebSocket server |
+| `apps/user-client` | 5001 | User-facing React PWA (mobile-first) |
+| `apps/admin-client` | 5002 | Admin portal React SPA |
+| `packages/shared` | — | Shared types, schema, constants |
+
+### Database (local PostgreSQL + neon wsproxy)
+
+The server uses `@neondatabase/serverless` which requires a WebSocket proxy to connect to local PostgreSQL. A Docker container running `ghcr.io/neondatabase/wsproxy` must be running on port 5433:
+
+```bash
+# Start PostgreSQL (if not running)
+sudo pg_ctlcluster 16 main start
+
+# Start Docker daemon (if not running)
+sudo dockerd &>/tmp/dockerd.log &
+
+# Start the neon wsproxy container (if not running)
+sudo docker run -d --name wsproxy -p 5433:80 \
+  --add-host=host.docker.internal:host-gateway \
+  -e ALLOW_ADDR_REGEX=".*" \
+  ghcr.io/neondatabase/wsproxy:latest
+```
+
+The server and CLI tools must be started with the neon local config preload:
+
+```bash
+# Start server with neon local config
+cd apps/server && node --env-file=../../.env --import ../../neon-local-config.mjs --import tsx/esm src/index.ts
+
+# Run CLI tools (e.g., admin:create) with neon local config
+cd apps/server && node --env-file=../../.env --import ../../neon-local-config.mjs --import tsx/esm src/cli/createAdminAccount.ts <args>
+```
+
+The `npm run dev:server` script does NOT include the neon preload, so you must start the server manually using the command above (or modify the script).
+
+### Starting services
+
+1. Ensure PostgreSQL is running: `pg_isready`
+2. Ensure Docker/wsproxy is running: `sudo docker ps | grep wsproxy`
+3. Start API server (in its own terminal with the neon preload command above)
+4. Start user client: `npm run dev:user`
+5. Start admin client: `npm run dev:admin`
+
+### Dev auth and admin access
+
+- **Phone login**: Use demo verification code `666666` in development mode.
+- **Admin account creation** (requires neon preload):
+  ```bash
+  cd apps/server && node --env-file=../../.env --import ../../neon-local-config.mjs --import tsx/esm src/cli/createAdminAccount.ts <username> <password> "$ADMIN_CREATE_SECRET_KEY" super_admin "Display Name"
+  ```
+- Admin login at `http://localhost:5002/admin/login`
+
+### Validation commands
+
+See `README.md` § "Validation commands" for full list. Key commands:
+
+- `npm run guardrails` — env files, secrets, import boundary checks
+- `npm run typecheck` — TypeScript across all workspaces
+- `npm run test` — tests across all workspaces (vitest for server)
+- `npm run lint` — lint all workspaces (currently aliased to typecheck)
+
+### Known issues in current codebase
+
+- `apps/user-client` has pre-existing TypeScript errors in `MatchingStatusPage.tsx` (null vs undefined type narrowing).
+- One server test (`orchestrationKickoff.test.ts`) expects `.vscode/settings.json` which may not exist.
+- The user client root page (`/`) may show a blank page due to a pre-existing runtime error in `DiscoverPage.tsx`; other routes like `/personality-test` render correctly.

--- a/apps/server/src/__tests__/neonLocalConfig.test.ts
+++ b/apps/server/src/__tests__/neonLocalConfig.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { neonConfig } from '@neondatabase/serverless';
+
+type NeonConfigSnapshot = {
+  webSocketConstructor: typeof neonConfig.webSocketConstructor;
+  wsProxy: typeof neonConfig.wsProxy;
+  useSecureWebSocket: typeof neonConfig.useSecureWebSocket;
+  pipelineTLS: typeof neonConfig.pipelineTLS;
+  pipelineConnect: typeof neonConfig.pipelineConnect;
+};
+
+function snapshotNeonConfig(): NeonConfigSnapshot {
+  return {
+    webSocketConstructor: neonConfig.webSocketConstructor,
+    wsProxy: neonConfig.wsProxy,
+    useSecureWebSocket: neonConfig.useSecureWebSocket,
+    pipelineTLS: neonConfig.pipelineTLS,
+    pipelineConnect: neonConfig.pipelineConnect,
+  };
+}
+
+function restoreNeonConfig(snapshot: NeonConfigSnapshot) {
+  neonConfig.webSocketConstructor = snapshot.webSocketConstructor;
+  neonConfig.wsProxy = snapshot.wsProxy;
+  neonConfig.useSecureWebSocket = snapshot.useSecureWebSocket;
+  neonConfig.pipelineTLS = snapshot.pipelineTLS;
+  neonConfig.pipelineConnect = snapshot.pipelineConnect;
+}
+
+function resolveProxyUrl(host: string, port: number | string) {
+  const { wsProxy } = neonConfig;
+  return typeof wsProxy === 'function' ? wsProxy(host, port) : `${wsProxy}?address=${host}:${port}`;
+}
+
+const originalConfig = snapshotNeonConfig();
+
+afterEach(() => {
+  restoreNeonConfig(originalConfig);
+});
+
+describe('neon-local-config', () => {
+  it('routes websocket proxy traffic to the requested database host and port', async () => {
+    vi.resetModules();
+
+    await import('../../../../neon-local-config.mjs');
+
+    expect(resolveProxyUrl('db.example.com', 6543)).toBe(
+      'localhost:5433/v1?address=db.example.com:6543',
+    );
+  });
+});

--- a/neon-local-config.mjs
+++ b/neon-local-config.mjs
@@ -1,0 +1,8 @@
+import { neonConfig } from '@neondatabase/serverless';
+import ws from 'ws';
+
+neonConfig.webSocketConstructor = ws;
+neonConfig.wsProxy = (host, port) => 'localhost:5433/v1?address=host.docker.internal:5432';
+neonConfig.useSecureWebSocket = false;
+neonConfig.pipelineTLS = false;
+neonConfig.pipelineConnect = false;

--- a/neon-local-config.mjs
+++ b/neon-local-config.mjs
@@ -1,8 +1,16 @@
 import { neonConfig } from '@neondatabase/serverless';
 import ws from 'ws';
 
+const LOCAL_DATABASE_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+function resolveDatabaseHost(host) {
+  // wsproxy runs in Docker, so loopback hosts need to point back to the host machine.
+  return LOCAL_DATABASE_HOSTS.has(host) ? 'host.docker.internal' : host;
+}
+
 neonConfig.webSocketConstructor = ws;
-neonConfig.wsProxy = (host, port) => 'localhost:5433/v1?address=host.docker.internal:5432';
+neonConfig.wsProxy = (host, port) =>
+  `localhost:5433/v1?address=${resolveDatabaseHost(host)}:${port}`;
 neonConfig.useSecureWebSocket = false;
 neonConfig.pipelineTLS = false;
 neonConfig.pipelineConnect = false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds development environment configuration files for local development and Cursor Cloud agent sessions, including full WeChat mini-program workspace support.

### Changes

- **`AGENTS.md`**: Cloud agent instructions covering architecture overview (all 4 workspaces including mini-program), local PostgreSQL + neon wsproxy setup, service startup commands, dev auth, validation commands, mini-program build/test/dev details, and known codebase issues.
- **`neon-local-config.mjs`**: Node.js preload script that configures `@neondatabase/serverless` to connect through a local wsproxy Docker container to PostgreSQL, enabling the Neon WebSocket driver to work with local databases.

### Context

The server uses `@neondatabase/serverless` (WebSocket-based PostgreSQL driver designed for Neon cloud). For local development, this requires a WebSocket proxy (`ghcr.io/neondatabase/wsproxy`) running in Docker. The preload script configures the driver to route connections through this proxy.

### Validation

**Web apps (server, user-client, admin-client):**
- ✅ `npm run guardrails` — passed
- ✅ `npm run dep-check` — passed
- ✅ `npm run typecheck` — shared, admin-client, server all pass (user-client has pre-existing TS errors)
- ✅ `npm run test` — 904 passed, 1 pre-existing failure
- ✅ Server API responds on port 5000
- ✅ Admin client renders and login works on port 5002
- ✅ User client renders on port 5001 (personality-test and other routes work)

**WeChat Mini Program (`apps/mini-program`):**
- ✅ `npm run typecheck -w mini-program` — passed
- ✅ `npm run build:weapp -w mini-program` — weapp build succeeded (7s)
- ✅ `npm run build:h5 -w mini-program` — H5 build succeeded (20s)
- ✅ `npm run dev:h5 -w mini-program` — H5 dev server running on port 10086
- ⚠️ `npx vitest run` (in mini-program) — 37/39 tests pass; 4 pre-existing failures

### Demo

[admin_login_and_navigation_demo.mp4](https://cursor.com/agents/bc-c7fc362d-14f3-4594-9490-5aa88268550f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_login_and_navigation_demo.mp4)

Admin portal login and navigation demo showing successful authentication and dashboard access.

[Admin dashboard with metrics](https://cursor.com/agents/bc-c7fc362d-14f3-4594-9490-5aa88268550f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_dashboard.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7fc362d-14f3-4594-9490-5aa88268550f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7fc362d-14f3-4594-9490-5aa88268550f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

