### PR TITLE
fix(mini-program): remove reintroduced '先做测试，再决定要不要登录' card from pers…

### DIFF
--- a/apps/mini-program/src/pages/onboarding/personality-test/index.scss
+++ b/apps/mini-program/src/pages/onboarding/personality-test/index.scss
@@ -86,32 +86,6 @@
     margin-bottom: $spacing-xl;
   }
 
-  &__intro-note {
-    @include card;
-    width: 100%;
-    max-width: 560rpx;
-    padding: $spacing-md;
-    margin-bottom: $spacing-lg;
-    text-align: left;
-    border: 2rpx solid rgba($color-primary, 0.08);
-    background: rgba($color-surface, 0.9);
-  }
-
-  &__intro-note-title {
-    display: block;
-    font-size: $font-size-base;
-    font-weight: $font-weight-semibold;
-    color: $color-text-primary;
-    margin-bottom: $spacing-xs;
-  }
-
-  &__intro-note-text {
-    display: block;
-    font-size: $font-size-sm;
-    color: $color-text-secondary;
-    line-height: 1.6;
-  }
-
   &__start-btn {
     @include button-primary;
     width: 100%;

--- a/apps/mini-program/src/pages/onboarding/personality-test/index.tsx
+++ b/apps/mini-program/src/pages/onboarding/personality-test/index.tsx
@@ -379,14 +379,6 @@ export default function PersonalityTestPage() {
             通过一系列有趣的问题，发现你独特的社交氛围原型
           </Text>
           <Text className='personality-test__hint'>大约需要 3-5 分钟，未登录也可以先完成</Text>
-          {!isAuthenticated ? (
-            <View className='personality-test__intro-note'>
-              <Text className='personality-test__intro-note-title'>先做测试，再决定要不要登录</Text>
-              <Text className='personality-test__intro-note-text'>
-                结果会先保存在当前设备里，登录后再继续进入 essential-data。
-              </Text>
-            </View>
-          ) : null}
           {error ? <Text className='personality-test__error'>{error}</Text> : null}
           <Button
             className='personality-test__start-btn'


### PR DESCRIPTION
…onality-test intro

The card was intentionally deleted in the original design. It was reintroduced in commit 48b6c778 when the intro page was refactored — the refactor replaced the old Card-based layout (which used a dynamic introNoteTitle/introNoteText computed from auth state) with a simpler View-based layout, but mistakenly re-added the note block as a hardcoded View conditional on !isAuthenticated.

Also removes the now-unused __intro-note / __intro-note-title / __intro-note-text SCSS rules from index.scss.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely removes an intro UI block and unused styling; no changes to assessment flow, API calls, or data handling.
> 
> **Overview**
> Removes the unauthenticated-only intro note card ("先做测试，再决定要不要登录") from the mini-program personality test intro screen.
> 
> Cleans up the associated now-unused styles by deleting `__intro-note`, `__intro-note-title`, and `__intro-note-text` rules from `index.scss`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 776481c649ca92d17bacbdf5b9f008c4a6e35570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->