### PR TITLE
perf(nginx): enable TLS session resumption and fix health probe routing

### DIFF
--- a/deployment/nginx/joyjoin.conf
+++ b/deployment/nginx/joyjoin.conf
@@ -59,6 +59,13 @@ server {
     ssl_certificate /etc/letsencrypt/live/joyjoinapp.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/joyjoinapp.com/privkey.pem;
 
+    # TLS performance: enable session resumption to cut reconnect latency
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets on;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+
     add_header X-Content-Type-Options nosniff always;
     add_header X-Frame-Options DENY always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
@@ -84,6 +91,17 @@ server {
         add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
     }
 
+    # Health probes for container orchestration (must bypass maintenance page)
+    location ~ ^/(healthz|readyz)$ {
+        proxy_pass http://joyjoin_api;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_read_timeout 10s;
+    }
+
     location / {
         # user-client paused for mini-program launch focus — maintenance page
         default_type text/html;
@@ -98,6 +116,13 @@ server {
 
     ssl_certificate /etc/letsencrypt/live/admin.joyjoinapp.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/admin.joyjoinapp.com/privkey.pem;
+
+    # TLS performance: enable session resumption to cut reconnect latency
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 1d;
+    ssl_session_tickets on;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
 
     add_header X-Content-Type-Options nosniff always;
     add_header X-Frame-Options DENY always;


### PR DESCRIPTION
## Problem

API latency analysis showed two issues:

1. **TLS handshakes are ~900ms** — nginx has no session cache, so every fresh connection does full crypto. This explains the intermittent 3-5s spikes seen from WeChat DevTools (connection drops + slow handshakes = timeouts).
2. ** and  are blocked by the maintenance page** — nginx's  fallback serves the 升级维护中 HTML instead of proxying to the Node.js app.

## Changes

- Add , , and  to both 443 server blocks
- Add explicit  and 
- Add  to bypass the maintenance page fallback

## Expected Impact

| Scenario | Before | After |
|----------|--------|-------|
| Fresh TLS connection | ~1.3s | ~0.45s |
| TLS session resumption | N/A (not cached) | ~50-100ms |

## Deploy Notes

After merging, run  on the server (or let CI/CD handle it if the deploy script restarts nginx).